### PR TITLE
Run unit and integration tests with Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/2019
+/2020
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ script:
   - python dbconnector.py
   # run tests
   - python -m pytest test/unit/test.py
+  - python -m pytest test/integration/integration.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ install:
 
   - pip install -r requirements.txt
 
-before_script:
   - cp secrets.travis.py secrets.py
-  # check database is ready
-  - python dbconnector.py
 
 script:
   - python -m pytest test/unit/test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,22 @@ language: python
 dist: bionic
 
 install:
-  # MSSQL support, 4 lines
+  # MSSQL support, 3 lines
   # until https://github.com/epam/OSCI/issues/2 is fixed
-  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -e 'MSSQL_PID=Express' -p 127.0.0.1:1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest-ubuntu
   - sudo apt-get -y install unixodbc-dev tdsodbc
   - sudo odbcinst -i -d -f /usr/share/tdsodbc/odbcinst.ini
 
   - pip install -r requirements.txt
 
-script:
-  # setup and test connection
-  - sed -i -r 's/SQL\+Server/FreeTDS/g' secrets.py
-  - git diff
-  # test connection
+before_script:
+  # MSSQL support, 1 line
+  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -e 'MSSQL_PID=Express' -p 127.0.0.1:1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+
+  - cp secrets.travis.py secrets.py
+  # check database is ready
   - python dbconnector.py
-  # run tests
+
+script:
   - python -m pytest test/unit/test.py
   - python -m pytest test/integration/integration.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,15 @@ language: python
 dist: bionic
 
 install:
-  # MSSQL support, 3 lines
+  # MSSQL support, 4 lines
   # until https://github.com/epam/OSCI/issues/2 is fixed
+  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -e 'MSSQL_PID=Express' -p 127.0.0.1:1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest-ubuntu
   - sudo apt-get -y install unixodbc-dev tdsodbc
   - sudo odbcinst -i -d -f /usr/share/tdsodbc/odbcinst.ini
 
   - pip install -r requirements.txt
 
 before_script:
-  # MSSQL support, 1 line
-  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -e 'MSSQL_PID=Express' -p 127.0.0.1:1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest-ubuntu
-
   - cp secrets.travis.py secrets.py
   # check database is ready
   - python dbconnector.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ install:
 script:
   # test connection
   - python dbconnector.py
+  # run tests
+  - python -m pytest test/unit/test.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ install:
 
 script:
   - python -m pytest test/unit/test.py
-  - python -m pytest test/integration/integration.py
+  # integration test are failing
+  # https://github.com/epam/OSCI/issues/9
+  #- python -m pytest test/integration/integration.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+
+dist: bionic
+
+install:
+  # MSSQL support, 4 lines
+  # until https://github.com/epam/OSCI/issues/2 is fixed
+  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -e 'MSSQL_PID=Express' -p 127.0.0.1:1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+  - sudo apt-get -y install unixodbc-dev tdsodbc
+  - sudo odbcinst -i -d -f /usr/share/tdsodbc/odbcinst.ini
+
+  - pip install -r requirements.txt
+
+script:
+  # test connection
+  - python dbconnector.py
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ install:
   - pip install -r requirements.txt
 
 script:
+  # setup and test connection
+  - sed -i -r 's/SQL\+Server/FreeTDS/g' secrets.py
+  - git diff
   # test connection
   - python dbconnector.py
   # run tests

--- a/dbconnector.py
+++ b/dbconnector.py
@@ -18,7 +18,7 @@
 
 import pyodbc
 
-from secrets import Server, PWD, UID
+from secrets import Server, PWD, UID, Driver
 
 
 class DBConnector:
@@ -27,13 +27,18 @@ class DBConnector:
         self.db_name = db_name
 
     def __enter__(self):
-        self.conn = pyodbc.connect('Driver={SQL Server};'
+        self.conn = pyodbc.connect('Driver={%s};'
                                    'Server=%s;'
+                                   'Port=1433;'
                                    'Database=%s;'
                                    'UID=%s;'
-                                   'PWD=%s;'
-                                   'Trusted_Connection=yes;' % (Server, self.db_name, UID, PWD), autocommit=True)
+                                   'PWD=%s;' % (Driver, Server, self.db_name, UID, PWD), autocommit=True)
         return self.conn
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.conn.close()
+
+
+if __name__ == "__main__":
+    with DBConnector("master") as conn:
+        print(conn)

--- a/secrets.py
+++ b/secrets.py
@@ -1,3 +1,6 @@
-UID = 'login'
-PWD = 'password'
-Server = 'server_name'
+# Default parameters for MS SQL docker image
+PWD = "yourStrong(!)Password"
+UID = "sa"
+Server = "127.0.0.1"
+Driver = "SQL+Server"
+# Driver = "FreeTDS"

--- a/secrets.travis.py
+++ b/secrets.travis.py
@@ -2,4 +2,4 @@
 PWD = "yourStrong(!)Password"
 UID = "sa"
 Server = "127.0.0.1"
-Driver = "SQL+Server"
+Driver = "FreeTDS"

--- a/test/integration/integration.py
+++ b/test/integration/integration.py
@@ -19,15 +19,16 @@
 import os
 import unittest
 import zipfile
+from pathlib import Path
 
 from file_loader import upload_files_from_directory
 from sql_runner import run_query_from_file
 
 
 class IntegrationTest(unittest.TestCase):
-    CWD = os.path.abspath(os.path.dirname(__file__))
-    FIXTURE_FOLDER = CWD + '/fixtures'
-    QUERY_FOLDER = os.path.abspath(CWD + "../../../SQL_queries/service_queries")
+    CWD = Path(__file__).parent.resolve()
+    FIXTURE_FOLDER = CWD / 'fixtures'
+    QUERY_FOLDER = CWD.parents[2] / "SQL_queries/service_queries"
     TMP_FOLDER = 'resources'
     TEST_DB_NAME = 'test_db'
 
@@ -36,6 +37,7 @@ class IntegrationTest(unittest.TestCase):
         if not os.path.exists(cls.TMP_FOLDER):
             os.mkdir(cls.TMP_FOLDER)
         path = os.path.join(cls.FIXTURE_FOLDER, 'create_test_db.sql')
+        assert os.path.exists(path)
         run_query_from_file('master', path)
         path = os.path.join(cls.QUERY_FOLDER, 'create_empty_tables.sql')
         run_query_from_file(database=cls.TEST_DB_NAME, path_to_file=path)

--- a/test/integration/integration.py
+++ b/test/integration/integration.py
@@ -25,7 +25,9 @@ from sql_runner import run_query_from_file
 
 
 class IntegrationTest(unittest.TestCase):
-    FIXTURE_FOLDER = 'fixtures'
+    CWD = os.path.abspath(os.path.dirname(__file__))
+    FIXTURE_FOLDER = CWD + '/fixtures'
+    QUERY_FOLDER = os.path.abspath(CWD + "../../../SQL_queries/service_queries")
     TMP_FOLDER = 'resources'
     TEST_DB_NAME = 'test_db'
 
@@ -35,8 +37,7 @@ class IntegrationTest(unittest.TestCase):
             os.mkdir(cls.TMP_FOLDER)
         path = os.path.join(cls.FIXTURE_FOLDER, 'create_test_db.sql')
         run_query_from_file('master', path)
-        path = os.path.join(os.path.abspath(os.path.join("..", os.pardir)), 'SQL_queries', 'service_queries',
-                            'create_empty_tables.sql')
+        path = os.path.join(cls.QUERY_FOLDER, 'create_empty_tables.sql')
         run_query_from_file(database=cls.TEST_DB_NAME, path_to_file=path)
 
     def _unzip_test_data(self):
@@ -47,11 +48,9 @@ class IntegrationTest(unittest.TestCase):
         self._unzip_test_data()
         path = os.path.join(self.TMP_FOLDER)
         upload_files_from_directory(path, database=self.TEST_DB_NAME)
-        path = os.path.join(os.path.abspath(os.path.join("..", os.pardir)), 'SQL_queries', 'service_queries',
-                            'create_filtered_table.sql')
+        path = os.path.join(self.QUERY_FOLDER, 'create_filtered_table.sql')
         run_query_from_file(database=self.TEST_DB_NAME, path_to_file=path)
-        path = os.path.join(os.path.abspath(os.path.join("..", os.pardir)), 'SQL_queries', 'reports',
-                            'top_commits_ranking.sql')
+        path = os.path.join(self.QUERY_FOLDER, 'top_commits_ranking.sql')
         result = run_query_from_file(database=self.TEST_DB_NAME, path_to_file=path)
         self.assertEqual(tuple(result[0]), ('Huawei', 2))
 

--- a/test/integration/integration.py
+++ b/test/integration/integration.py
@@ -28,7 +28,7 @@ from sql_runner import run_query_from_file
 class IntegrationTest(unittest.TestCase):
     CWD = Path(__file__).parent.resolve()
     FIXTURE_FOLDER = CWD / 'fixtures'
-    QUERY_FOLDER = CWD.parents[2] / "SQL_queries/service_queries"
+    QUERY_FOLDER = CWD.parents[1] / "SQL_queries/service_queries"
     TMP_FOLDER = 'resources'
     TEST_DB_NAME = 'test_db'
 

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -27,7 +27,8 @@ from shutil import copy2
 
 
 class TestModules(unittest.TestCase):
-    FIXTURE_FOLDER = 'fixtures'
+    CWD = os.path.abspath(os.path.dirname(__file__))
+    FIXTURE_FOLDER = CWD + '/fixtures'
     TMP_FOLDER = 'resources'
     ARCHIVE_FILE = '2019-01-01-23.json.gz'
     FILE = '2019-01-01-23.json'

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -18,6 +18,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 import mock
 
@@ -27,8 +28,8 @@ from shutil import copy2
 
 
 class TestModules(unittest.TestCase):
-    CWD = os.path.abspath(os.path.dirname(__file__))
-    FIXTURE_FOLDER = CWD + '/fixtures'
+    CWD = Path(__file__).parent.resolve()
+    FIXTURE_FOLDER = CWD / 'fixtures'
     TMP_FOLDER = 'resources'
     ARCHIVE_FILE = '2019-01-01-23.json.gz'
     FILE = '2019-01-01-23.json'


### PR DESCRIPTION
I refactored #3 to remove SQLAlchemy code and make it easier to review and fix the error with loading data by switching from using local files to passing JSON over the network described in https://github.com/epam/OSCI/pull/3#issuecomment-577647551

This is ready for review and merge.

---

**UPDATE 20200204**: Explaining why Travis tests in this PR fail. The failure is at https://travis-ci.com/epam/OSCI/builds/146068537#L385
```
E           pyodbc.ProgrammingError: ('42000', '[42000] [FreeTDS][SQL Server]Cannot bulk load. The file "/home/travis/build/epam/OSCI/resources/2019-01-01-9-formatted.json" does not exist or you don\'t have file access rights. (4860) (SQLExecDirectW)')
```
Which means that MS SQL is trying to access filename on **its local filesystem**. There is no problem with running the software on @patrickstephens1 computer (or whoever does the monthly report), because they use Windows with MS SQL installed on the same machine. MS SQL there shares filesystem with Python scripts and is able to access the file referenced in its T-SQL load query. When DB server is remote as in this case with Travis and other Linux machines, the DB is unable to find the file and fails.

The solution to fix the test is to ask T-SQL expert to rewrite the data loading SQL to get data from Python and not from the filesystem directly.