### PR TITLE
Add num repos per company & number comp commits per repositories reports

### DIFF
--- a/osci/actions/__init__.py
+++ b/osci/actions/__init__.py
@@ -3,7 +3,11 @@ from .base import Action, ActionParam
 from .filter import FilterUnlicensedAction, FilterListCompanyProjectsAction
 from .load import LoadCompanyCommitsAction
 from .notify import GenerateEmailAction, ContributorsRankingMbmReportAction
-from .postprocess import FindContributorsRepositoriesChangeAction, OSCIChangeReportAction
+from .postprocess import (
+    FindContributorsRepositoriesChangeAction,
+    OSCIChangeReportAction,
+    GetNumberOfRepositoriesPerCompanyAction,
+)
 from .preprocess import (
     MatchCompanyAction,
     LoadRepositoriesAction,

--- a/osci/actions/postprocess/__init__.py
+++ b/osci/actions/postprocess/__init__.py
@@ -1,2 +1,4 @@
 from .find_new_repos_and_commiters import FindContributorsRepositoriesChangeAction
 from .osci_change_report import OSCIChangeReportAction
+from .get_num_repos_for_companies import GetNumberOfRepositoriesPerCompanyAction
+from .get_num_companies_commit_per_repo import GetNumberOfCompaniesCommitsPerRepositoryAction

--- a/osci/actions/postprocess/get_num_companies_commit_per_repo.py
+++ b/osci/actions/postprocess/get_num_companies_commit_per_repo.py
@@ -1,0 +1,33 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
+from osci.actions import Action
+from datetime import datetime
+from osci.postprocess.get_num_companies_commit_per_repo import get_num_companies_commit_per_repository
+from osci.datalake.reports.general.companies_commits_per_repo import CompaniesCommitsPerRepositoriesDTD
+
+
+class GetNumberOfCompaniesCommitsPerRepositoryAction(Action):
+    """Count number companies commits per repositories"""
+
+    @classmethod
+    def name(cls) -> str:
+        return 'get-number-of-companies-commits-per-repository'
+
+    def _execute(self, day: datetime):
+        report = CompaniesCommitsPerRepositoriesDTD(date=day)
+        report.save(get_num_companies_commit_per_repository(date=day))
+        return report

--- a/osci/actions/postprocess/get_num_repos_for_companies.py
+++ b/osci/actions/postprocess/get_num_repos_for_companies.py
@@ -1,0 +1,33 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
+from osci.actions import Action
+from datetime import datetime
+from osci.postprocess.get_num_repos_per_company import get_num_repos_per_company
+from osci.datalake.reports.general.repos_per_company import RepositoriesPerCompanyDTD
+
+
+class GetNumberOfRepositoriesPerCompanyAction(Action):
+    """Count number of repositories per company"""
+
+    @classmethod
+    def name(cls) -> str:
+        return 'get-number-of-repositories-per-company'
+
+    def _execute(self, day: datetime):
+        report = RepositoriesPerCompanyDTD(date=day)
+        report.save(get_num_repos_per_company(date=day))
+        return report

--- a/osci/config/base.py
+++ b/osci/config/base.py
@@ -124,7 +124,6 @@ class WebConfig(NamedTuple):
 
 
 def parse_web_config(web_cfg) -> WebConfig:
-    log.debug(web_cfg)
     fs = web_cfg['fs']
     attrs_map = {
         FileSystemType.local: dict(base_path=web_cfg['base_path'],
@@ -161,7 +160,6 @@ class Config(BaseConfig):
                                                     if BaseYmlConfigReader(env='local').exists()
                                                     else None) or 'default'
         self.__cfg = BaseYmlConfigReader(self.env, dbutils=dbutils).config
-        log.info(f"Full config: {self.__cfg}")
         log.info(f'Configuration loaded for env: {self.env}')
 
         file_system_type_map: Mapping[str, type(FileSystemConfig)] = {

--- a/osci/config/reader.py
+++ b/osci/config/reader.py
@@ -95,7 +95,6 @@ def read_config_from_environ(config: dict, *args, **kwargs) -> dict:
             }
         if isinstance(variable, list):
             return [_load_variables_from_env(v) for v in variable]
-        print('key', variable, 'value', os.environ.get(str(variable)))
         return os.environ.get(str(variable))
 
     return {k: _load_variables_from_env(v) for k, v in config.items() if k != META_CONFIG_FIELD}
@@ -140,7 +139,6 @@ class BaseYmlConfigReader(BaseConfigReader):
             log.debug(f'Read config from {self.file_path}')
             with open(self.file_path) as config_file:
                 self.__cfg = yaml.load(config_file, Loader=yaml.FullLoader)
-                log.debug(f"Prod yml load: {self.__cfg}")
                 meta = self.__cfg[META_CONFIG_FIELD].copy()
                 if meta[CONFIG_SOURCE_TYPE_FIELD] in readers_types_map:
                     self.__cfg = readers_types_map[meta[CONFIG_SOURCE_TYPE_FIELD]](self.__cfg, self.dbutils)
@@ -151,7 +149,6 @@ class BaseYmlConfigReader(BaseConfigReader):
                                             file_format=self.file_format).config,
                         self.__cfg
                     )
-                log.debug(f"Prod yml res: {self.__cfg}")
                 return self.__cfg
         except FileNotFoundError as ex:
             log.error(ex)

--- a/osci/datalake/base.py
+++ b/osci/datalake/base.py
@@ -265,12 +265,11 @@ class BasePublicArea(BaseDataLakeArea, abc.ABC):
     def save_companies_contributors_repository_commits(self, df: pd.DataFrame, date: datetime):
         raise NotImplementedError()
 
-    def get_companies_contributors_repository_commits(self, date: datetime) -> pd.DataFrame:
+    def get_companies_contributors_repository_commits(self, name: str, date: datetime) -> pd.DataFrame:
         raise NotImplementedError()
 
 
 class BaseWebArea(abc.ABC):
-
     _osci_ranking_dir_name = 'osci-ranking'
     _osci_ranking_monthly_dir_name = 'monthly'
 

--- a/osci/datalake/blob/public.py
+++ b/osci/datalake/blob/public.py
@@ -103,3 +103,9 @@ class BlobPublicArea(BasePublicArea, BlobArea):
 
     def save_email(self, email_body: str, date: datetime):
         self.write_string_to_file(path=self._get_email_path(date=date), data=email_body, content_type='text/html')
+
+    def get_companies_contributors_repository_commits(self, name: str, date: datetime) -> pd.DataFrame:
+        path = self._report_base_path
+        full_path = date.strftime(
+            f'{path}/{name}/{name}_%Y-%m-%d.csv')
+        return self.read_pandas_dataframe_from_csv(path=full_path)

--- a/osci/datalake/companies_contributors_repository_commits/__init__.py
+++ b/osci/datalake/companies_contributors_repository_commits/__init__.py
@@ -15,7 +15,6 @@
    You should have received a copy of the GNU General Public License
    along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
 from osci.datalake import DataLake
-
 import datetime
 import pandas as pd
 
@@ -25,6 +24,11 @@ class CompaniesContributorsRepository:
 
     def __init__(self, date: datetime.datetime):
         self.date = date
+
+    @property
+    def name(self) -> str:
+        """Name of report"""
+        return 'Company-contributors-repository-commits_YTD'
 
     @property
     def path(self) -> str:
@@ -51,4 +55,4 @@ class CompaniesContributorsRepository:
         """
         Read company contributors repository commits to pandas DataFrame from file
         """
-        return DataLake().public.get_companies_contributors_repository_commits(self.date)
+        return DataLake().public.get_companies_contributors_repository_commits(name=self.name, date=self.date)

--- a/osci/datalake/local/base.py
+++ b/osci/datalake/local/base.py
@@ -31,7 +31,6 @@ class LocalSystemArea(BaseDataLakeArea):
         super().__init__()
         self.BASE_PATH = Path(base_path)
         self.BASE_AREA_DIR = base_area_dir
-        print(self, base_path, base_area_dir)
 
     def add_fs_prefix(self, path: Union[Path, str]) -> str:
         return f'{self.FS_PREFIX}:///{path}'

--- a/osci/datalake/local/public.py
+++ b/osci/datalake/local/public.py
@@ -102,3 +102,10 @@ class LocalPublicArea(BasePublicArea, LocalSystemArea):
     def save_email(self, email_body: str, date: datetime):
         with open(str(self._get_email_path(date=date)), 'w', encoding='utf-8') as f:
             f.write(email_body)
+
+    def get_companies_contributors_repository_commits(self, name: str, date: datetime) -> pd.DataFrame:
+        path = self._report_base_path / name
+        path.mkdir(parents=True, exist_ok=True)
+        filename = f'{name}_{date.strftime("%Y-%m-%d")}.csv'
+        full_path = path / filename
+        return pd.read_csv(full_path)

--- a/osci/datalake/reports/general/companies_commits_per_repo.py
+++ b/osci/datalake/reports/general/companies_commits_per_repo.py
@@ -1,0 +1,32 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
+from typing import Type
+
+from osci.datalake.schemas.public import NumberOfCompaniesCommitsInRepositories
+from osci.datalake import DatePeriodType
+
+from .base import Report, GeneralReportFactory
+
+
+class CompaniesCommitsPerRepositoriesFactory(GeneralReportFactory):
+    report_base_cls: Type[Report] = type('_Report', (Report,),
+                                         dict(base_name='OSCI_Commits_per_repositories',
+                                              schema=NumberOfCompaniesCommitsInRepositories))
+
+
+class CompaniesCommitsPerRepositoriesDTD(CompaniesCommitsPerRepositoriesFactory.report_base_cls):
+    date_period = DatePeriodType.DTD

--- a/osci/datalake/reports/general/repos_per_company.py
+++ b/osci/datalake/reports/general/repos_per_company.py
@@ -1,0 +1,32 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
+from typing import Type
+
+from osci.datalake.schemas.public import NumberRepositoryPerCompaniesSchema
+from osci.datalake import DatePeriodType
+
+from .base import Report, GeneralReportFactory
+
+
+class RepositoriesPerCompanyFactory(GeneralReportFactory):
+    report_base_cls: Type[Report] = type('_Report', (Report,),
+                                         dict(base_name='Repositories-per-company',
+                                              schema=NumberRepositoryPerCompaniesSchema))
+
+
+class RepositoriesPerCompanyDTD(RepositoriesPerCompanyFactory.report_base_cls):
+    date_period = DatePeriodType.DTD

--- a/osci/datalake/schemas/public.py
+++ b/osci/datalake/schemas/public.py
@@ -152,7 +152,7 @@ class NumberRepositoryPerCompaniesSchema:
 
 class NumberOfCompaniesCommitsInRepositories:
     company = 'Company'
-    repository = 'Repositories'
+    repository = 'Repository'
     commits = 'Commits'
 
 

--- a/osci/datalake/schemas/public.py
+++ b/osci/datalake/schemas/public.py
@@ -145,6 +145,17 @@ class CompaniesContributorsRepositoryCommits:
     date = 'date'
 
 
+class NumberRepositoryPerCompaniesSchema:
+    company = 'Company'
+    repository = 'Repositories'
+
+
+class NumberOfCompaniesCommitsInRepositories:
+    company = 'Company'
+    repository = 'Repositories'
+    commits = 'Commits'
+
+
 class OSCIContributorsRankingSchema:
     company = 'Company'
     author = 'Contributor'
@@ -165,3 +176,4 @@ class PublicSchemas:
     new_repos = NewReposSchema
     company_contributors_repository_commits = CompaniesContributorsRepositoryCommits
     osci_contributors_ranking = OSCIContributorsRankingSchema
+    num_rep_per_company = NumberRepositoryPerCompaniesSchema

--- a/osci/postprocess/find_new_repos_and_commiters.py
+++ b/osci/postprocess/find_new_repos_and_commiters.py
@@ -1,3 +1,19 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
 import datetime
 import pandas as pd
 

--- a/osci/postprocess/get_num_companies_commit_per_repo.py
+++ b/osci/postprocess/get_num_companies_commit_per_repo.py
@@ -1,0 +1,34 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
+import pandas as pd
+from datetime import datetime
+from osci.datalake import CompaniesContributorsRepository
+from osci.datalake.schemas.public import NumberOfCompaniesCommitsInRepositories
+
+
+def get_num_companies_commit_per_repository(date: datetime) -> pd.DataFrame:
+    """Get number of companies commits in repositories"""
+    report_schema = NumberOfCompaniesCommitsInRepositories
+    schema = CompaniesContributorsRepository.schema
+    rep_per_comp_df = CompaniesContributorsRepository(date=date).read()
+    return rep_per_comp_df[[schema.company, schema.repository, schema.commits]] \
+        .groupby([schema.company, schema.repository]) \
+        .sum() \
+        .reset_index() \
+        .rename(columns={schema.repository: report_schema.repository,
+                         schema.company: report_schema.company,
+                         schema.commits: report_schema.commits})

--- a/osci/postprocess/get_num_repos_per_company.py
+++ b/osci/postprocess/get_num_repos_per_company.py
@@ -1,0 +1,33 @@
+"""Copyright since 2021, EPAM Systems
+
+   This file is part of OSCI.
+
+   OSCI is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OSCI is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OSCI.  If not, see <http://www.gnu.org/licenses/>."""
+import pandas as pd
+from datetime import datetime
+from osci.datalake import CompaniesContributorsRepository
+from osci.datalake.schemas.public import NumberRepositoryPerCompaniesSchema
+
+
+def get_num_repos_per_company(date: datetime) -> pd.DataFrame:
+    """Get number of repositories per companies"""
+    report_schema = NumberRepositoryPerCompaniesSchema
+    schema = CompaniesContributorsRepository.schema
+    rep_per_comp_df = CompaniesContributorsRepository(date=date).read()
+    return rep_per_comp_df[[schema.company, schema.repository]] \
+        .groupby([schema.company]) \
+        .count() \
+        .reset_index() \
+        .rename(columns={schema.repository: report_schema.repository,
+                         schema.company: report_schema.company})

--- a/osci/utils.py
+++ b/osci/utils.py
@@ -80,3 +80,9 @@ def get_compared_date(day: datetime):
     if day.month == 1:
         return datetime(year=day.year, month=day.month, day=1)
     return datetime(year=day.year, month=day.month, day=1) - timedelta(days=1)
+
+
+def days_range(start: datetime, end: datetime, delta=timedelta(days=1)):
+    while start < end:
+        yield start
+        start += delta

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pypandoc==1.5
 pyspark == 3.0.1
 pytest==6.0.1
+pytest-mock==3.5.1
 -r __app__/requirements.txt
 -r osci/requirements.txt

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,8 @@ import pyspark
 import pytest
 import pandas as pd
 
+from datetime import datetime
+
 from osci.datalake import DataLake
 
 
@@ -60,3 +62,8 @@ def staging_push_event_commit_df():
          DataLake().staging.schemas.push_commits.language: "Python",
          DataLake().staging.schemas.push_commits.license: "gpl-3.0"
          }])
+
+
+@pytest.fixture(scope='session')
+def load_date():
+    return datetime(year=2021, month=1, day=1)

--- a/test/get_num_companies_commits_per_repo/test_get_num_companies_commits_per_repo.py
+++ b/test/get_num_companies_commits_per_repo/test_get_num_companies_commits_per_repo.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import pytest
+from datetime import datetime
+from osci.postprocess.get_num_companies_commit_per_repo import get_num_companies_commit_per_repository
+from osci.datalake.schemas.public import NumberOfCompaniesCommitsInRepositories
+from pandas._testing import assert_frame_equal
+from osci.datalake import CompaniesContributorsRepository
+
+
+@pytest.fixture()
+def comp_contrib_repos_complex_df():
+    return pd.DataFrame([
+        {CompaniesContributorsRepository.schema.author_name: "Author Name",
+         CompaniesContributorsRepository.schema.author_email: "email@email.com",
+         CompaniesContributorsRepository.schema.company: "Company1",
+         CompaniesContributorsRepository.schema.commits: 42,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+        {CompaniesContributorsRepository.schema.author_name: "Author Name2",
+         CompaniesContributorsRepository.schema.author_email: "email2@email.com",
+         CompaniesContributorsRepository.schema.company: "Company1",
+         CompaniesContributorsRepository.schema.commits: 73,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+        {CompaniesContributorsRepository.schema.author_name: "Author Name2",
+         CompaniesContributorsRepository.schema.author_email: "email2@email.com",
+         CompaniesContributorsRepository.schema.company: "Company2",
+         CompaniesContributorsRepository.schema.commits: 73,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "ya-repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+        {CompaniesContributorsRepository.schema.author_name: "Author Name3",
+         CompaniesContributorsRepository.schema.author_email: "email3@email.com",
+         CompaniesContributorsRepository.schema.company: "Company2",
+         CompaniesContributorsRepository.schema.commits: 128,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+    ])
+
+
+@pytest.fixture()
+def expected():
+    return pd.DataFrame([
+        {NumberOfCompaniesCommitsInRepositories.company: "Company1",
+         NumberOfCompaniesCommitsInRepositories.repository: 'repo/name',
+         NumberOfCompaniesCommitsInRepositories.commits: 115},
+        {NumberOfCompaniesCommitsInRepositories.company: "Company2",
+         NumberOfCompaniesCommitsInRepositories.repository: 'repo/name',
+         NumberOfCompaniesCommitsInRepositories.commits: 128},
+        {NumberOfCompaniesCommitsInRepositories.company: "Company2",
+         NumberOfCompaniesCommitsInRepositories.repository: 'ya-repo/name',
+         NumberOfCompaniesCommitsInRepositories.commits: 73},
+    ])
+
+
+def test_get_num_companies_commits_per_repo(mocker, comp_contrib_repos_complex_df, load_date,
+                                            expected):
+    mocker.patch("osci.datalake.CompaniesContributorsRepository.read", return_value=comp_contrib_repos_complex_df)
+    res = get_num_companies_commit_per_repository(load_date)
+    assert_frame_equal(res, expected)

--- a/test/get_num_repos_per_company/test_get_num_rep_per_company.py
+++ b/test/get_num_repos_per_company/test_get_num_rep_per_company.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import pytest
+from datetime import datetime
+from osci.postprocess.get_num_repos_per_company import get_num_repos_per_company
+from osci.datalake.schemas.public import NumberRepositoryPerCompaniesSchema
+from pandas._testing import assert_frame_equal
+from osci.datalake import CompaniesContributorsRepository
+
+
+@pytest.fixture()
+def num_per_per_comp_single_expected():
+    return pd.DataFrame([
+        {NumberRepositoryPerCompaniesSchema.company: "Company",
+         NumberRepositoryPerCompaniesSchema.repository: 1}
+    ])
+
+
+@pytest.fixture()
+def comp_contrib_repos_complex_df():
+    return pd.DataFrame([
+        {CompaniesContributorsRepository.schema.author_name: "Author Name",
+         CompaniesContributorsRepository.schema.author_email: "email@email.com",
+         CompaniesContributorsRepository.schema.company: "Company1",
+         CompaniesContributorsRepository.schema.commits: 11111,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+        {CompaniesContributorsRepository.schema.author_name: "Author Name2",
+         CompaniesContributorsRepository.schema.author_email: "email2@email.com",
+         CompaniesContributorsRepository.schema.company: "Company2",
+         CompaniesContributorsRepository.schema.commits: 22222,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+        {CompaniesContributorsRepository.schema.author_name: "Author Name3",
+         CompaniesContributorsRepository.schema.author_email: "email3@email.com",
+         CompaniesContributorsRepository.schema.company: "Company2",
+         CompaniesContributorsRepository.schema.commits: 33333,
+         CompaniesContributorsRepository.schema.license: "other",
+         CompaniesContributorsRepository.schema.repository: "repo/name",
+         CompaniesContributorsRepository.schema.language: "python",
+         CompaniesContributorsRepository.schema.date: datetime(year=2021, month=1, day=1)
+         },
+    ])
+
+
+@pytest.fixture()
+def num_per_per_comp_complex_expected():
+    return pd.DataFrame([
+        {NumberRepositoryPerCompaniesSchema.company: "Company1",
+         NumberRepositoryPerCompaniesSchema.repository: 1},
+        {NumberRepositoryPerCompaniesSchema.company: "Company2",
+         NumberRepositoryPerCompaniesSchema.repository: 2},
+    ])
+
+
+def test_num_per_per_companies_success(mocker, comp_contrib_repos_complex_df, load_date,
+                                       num_per_per_comp_complex_expected):
+    mocker.patch("osci.datalake.CompaniesContributorsRepository.read", return_value=comp_contrib_repos_complex_df)
+    res = get_num_repos_per_company(load_date)
+    assert_frame_equal(res, num_per_per_comp_complex_expected)

--- a/test/load_comp_contrib_repos_to_bq/test_load_comp_contrib_repos_to_bq.py
+++ b/test/load_comp_contrib_repos_to_bq/test_load_comp_contrib_repos_to_bq.py
@@ -6,11 +6,6 @@ from osci.publishing import load_companies_contrib_repos_to_bq
 
 
 @pytest.fixture()
-def load_date():
-    return datetime(year=2021, month=1, day=1)
-
-
-@pytest.fixture()
 def comp_contrib_repos_df():
     return pd.DataFrame([
         {CompaniesContributorsRepository.schema.author_name: "Author Name",

--- a/test/unit/test_postprocessers/test_change_report.py
+++ b/test/unit/test_postprocessers/test_change_report.py
@@ -90,8 +90,10 @@ def test_get_contributors_ranking_mbm_change_report():
         {contributor_field: 'User4', jan.strftime('%b'): 0, feb.strftime('%b'): 0, dec.strftime('%b'): 1, 'Total': 1},
     ])
 
+    for date in (jan, feb, dec):
+        reference[date.strftime('%b')] = reference[date.strftime('%b')].astype('int32')
+
     df = get_contributors_ranking_mbm_change_report(reports,
                                                     contributor_field=contributor_field,
                                                     commits_amount_field=commits_amount_field)
-
     pd.testing.assert_frame_equal(reference, df)


### PR DESCRIPTION
Added two reports:
1) `Repositories-per-company` showing the number of repositories that company employees have committed to on that day.
2) `OSCI_Commits_per_repositories` showing the number of commits from company employees to a specific repository per day.

At the moment, it is not planned to include this report in the daily pipeline. It is supposed to be used manually via cli or, if deployed, via azf.