### PR TITLE
Remove egencia from expedia domains.

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -456,7 +456,6 @@
     - ^.*\.exoplatform\.org$
 - company: Expedia Group
   domains:
-    - egencia.com
     - expedia.com
     - expediagroup.com
     - hotels.com


### PR DESCRIPTION
Removes Egencia from the Expedia Group domains as it is now a separate company.