### PR TITLE
Adding XWiki SAS company to company list

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -1764,3 +1764,10 @@
     - linagora.com
   industry: Technology
   regex:
+  company: XWiki SAS
+  domains:
+    - xwiki.com
+    - xwiki.org
+    - cryptpad.fr
+  industry: Technology
+  regex:


### PR DESCRIPTION
XWiki SAS is the main developer of the XWiki & CryptPad open source projects.