### PR TITLE
Add Instituto Superior Técnico (IST) to the company's list

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -816,6 +816,14 @@
     - instructure.com
   industry: Technology
   regex:
+- company: Instituto Superior Técnico
+  domains:
+    - tecnico.ulisboa.pt
+    - ist.utl.pt
+  industry: Education
+  regex:
+    - ^.*\.tecnico\.ulisboa\.pt$
+    - ^.*\.ist\.utl\.pt$
 - company: Intel
   domains:
     - intel.com


### PR DESCRIPTION
It's an university. It uses two domain, with the 2nd redirecting to the 1st:
 - https://tecnico.ulisboa.pt
 - https://ist.utl.pt