### PR TITLE
Extend matching for SUSE with Rancher and Neuvector

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -1319,10 +1319,12 @@
 - company: SUSE
   domains:
     - suse.com
+    - rancher.com
+    - neuvector.com
   industry: Technology
   regex:
-    - ^.*\.suse\..*$
-    - ^suse\..*$
+    - ^.*\.(rancher|neuvector|suse)\..*$
+    - ^(rancher|neuvector|suse)\..*$
 - company: SYSOP
   domains:
     - sysop.cz


### PR DESCRIPTION
Rancher and Neuvector are part of SUSE group, see
https://www.suse.com/c/suse-acquires-rancher/
https://www.suse.com/news/suse-acquires-neuvector/

Signed-off-by: Dirk Müller <dmueller@suse.com>