### PR TITLE
FIX: reduce load-repositories download time

### DIFF
--- a/osci/crawlers/github/rest.py
+++ b/osci/crawlers/github/rest.py
@@ -84,7 +84,6 @@ class GithubRest(requests.Session):
                         f'Wait til {self.limits.limit_reset_time} ({wait})'
                         f'url=`{url}`')
 
-            time.sleep(wait.total_seconds())
 
             log.debug(f"Retry making request to Github API method={method}, url={url}, kwargs={kwargs} "
                       f"after reset limits")


### PR DESCRIPTION
the load-repositories will pause the download and wait for a long time
We can remove the wait time reduce the total run time for the action.