### PR TITLE
FIX: java.lang.OutOfMemoryError: Java heap space

### DIFF
--- a/osci/jobs/session.py
+++ b/osci/jobs/session.py
@@ -26,7 +26,7 @@ class Session(metaclass=MetaSingleton):
 
     def build_session(self):
         builder = SparkSession.builder
-        self._ssc = builder.getOrCreate()
+        self._ssc = builder.config("spark.driver.memory", "6g").getOrCreate()
 
     @property
     def spark_session(self) -> SparkSession:


### PR DESCRIPTION
fix error
java.lang.OutOfMemoryError: Java heap space
ERROR Executor: Exception in task 15.0 in stage 2.0 (TID 4305)
        at java.base/java.lang.StringLatin1.newString(StringLatin1.java:715)
        at java.base/java.lang.StringBuffer.toString(StringBuffer.java:720)
        at scala.util.matching.Regex.replaced(Regex.scala:897)
        at scala.util.matching.Regex.replaced
        at scala.util.matching.Regex1422803anon.replaced(Regex.scala:878)
        at scala.util.matching.Regex.replaceAllIn(Regex.scala:509)
        at org.apache.spark.internal.config.ConfigReader.substitute(ConfigReader.scala:88)
        at org.apache.spark.internal.config.ConfigReader.substitute(ConfigReader.scala:84)
        at org.apache.spark.internal.config.ConfigEntryWithDefaultString.(ConfigEntry.scala:205)
        at org.apache.spark.internal.config.ConfigEntryWithDefaultString1422803Lambda97/0x00000008402d8440.apply(Unknown Source)
        at scala.Option.getOrElse(Option.scala:189)
        at org.apache.spark.internal.config.ConfigEntryWithDefaultString.readFrom(ConfigEntry.scala:205)
        at org.apache.spark.SparkConf.get(SparkConf.scala:261)
        at org.apache.spark.io.LZ4CompressionCodec.compressedOutputStream(CompressionCodec.scala:137)
        at org.apache.spark.serializer.SerializerManager.wrapForCompression(SerializerManager.scala:159)
        at org.apache.spark.serializer.SerializerManager.wrapStream(SerializerManager.scala:134)
        at org.apache.spark.storage.DiskBlockObjectWriter.open(DiskBlockObjectWriter.scala:156)
        at org.apache.spark.storage.DiskBlockObjectWriter.write(DiskBlockObjectWriter.scala:279)
        at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:171)
        at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
        at org.apache.spark.scheduler.Task.run(Task.scala:131)
        at org.apache.spark.executor.Executor.(Executor.scala:506)
        at org.apache.spark.executor.Executor1422803Lambda598/0x0000000840a4c840.apply(Unknown Source)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1462)
        at org.apache.spark.executor.Executor.run(Executor.scala:509)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
