### PR TITLE
Add Alliander to the company list

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -85,6 +85,16 @@
   regex:
     - ^.*\.aliyun\.com$
     - ^.*\.alibaba-inc\.com$
+- company: Alliander
+  domains:
+    - alliander.com
+    - alliander.de
+    - entrnce.com
+    - exe.energy
+    - firan.nl
+    - kenter.nu
+    - qirion.nl
+  industry: Energy & Utilities
 - company: Amazon
   domains:
     - amazon.com


### PR DESCRIPTION
Include Alliander and its subsidiaries. More on Alliander strategic open source projects at: https://www.alliander.com/nl/open-source/ There have been other subsidiaries in the past with different domains, but as OSCI doesn't consider historic commits I assume this isn't worth adding.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>