### PR TITLE
Rename Ant Financial to Ant Group

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -102,11 +102,18 @@
   industry: Technology
   regex:
     - ^.*\.andela\.com$
-- company: Ant Financial
+- company: Ant Group
   domains:
+    - antgroup.com
     - antfin.com
+    - alipay.com
+    - hyper.sh
   industry: Banking, Insurance & Financial Services
   regex:
+    - ^.*\.antgroup\.com$
+    - ^.*\.antfin\.com$
+    - ^.*\.alipay\.com$
+    - ^.*\.hyper\.sh$
 - company: Antmicro
   domains:
     - antmicro.com


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

`Ant Financial` has rename to `Ant Group`, refer to https://en.wikipedia.org/wiki/Ant_Group.