### PR TITLE
Fix typo in quantco.com domain

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -1315,7 +1315,7 @@
   regex:
 - company: QuantCo
   domains:
-    - qauntco.com
+    - quantco.com
   industry: Technology
   regex:
 - company: RStudio


### PR DESCRIPTION
QuantCo wasn't appearing in the OSCI and this seems to be the reason.