### PR TITLE
Update company_domain_match_list.yaml correcting Meta's domain

### DIFF
--- a/osci/preprocess/match_company/company_domain_match_list.yaml
+++ b/osci/preprocess/match_company/company_domain_match_list.yaml
@@ -626,10 +626,12 @@
   domains:
     - fb.com
     - facebook.com
+    - meta.com
   industry: Technology
   regex:
     - ^.*\.fb\.com$
     - ^.*\.facebook\.com$
+    - ^.*\.meta\.com$
 - company: Financial Times
   domains:
     - ft.com


### PR DESCRIPTION
Adding meta.com domain as Meta changed their e-mail addresses' domain in 2022.